### PR TITLE
Fixed commas in library.json breaking platformio build

### DIFF
--- a/library.json
+++ b/library.json
@@ -4,7 +4,7 @@
   "keywords": "m5ez, m5stack, esp32",
   "authors": {
     "name": "Rop Gonggrijp",
-    "url": "https://github.com/ropg"
+    "url": "https://github.com/ropg",
     "maintainer": true
   },
   "repository": {
@@ -16,7 +16,7 @@
   },
   "version": "1.3.1",
   "framework": "arduino",
-  "platforms": "espressif32"
+  "platforms": "espressif32",
   "build": {
     "libArchive": false
   }


### PR DESCRIPTION
A couple of commas missing from library.json meant platformio was skipping the library