### PR TITLE
M5Stack Power is used for battery level retrieval

### DIFF
--- a/src/M5ez.h
+++ b/src/M5ez.h
@@ -565,7 +565,8 @@ class ezSettings {
 			static void writeFlash();
 			static void menu();
 			static uint16_t loop();
-			static uint8_t getBatteryLevel();
+			static uint8_t getTransformedBatteryLevel();
+			static uint32_t getBatteryBarColor(uint8_t batteryLevel);
 		private:
 			static bool _on;
 			static void _refresh();


### PR DESCRIPTION
Hello Rop! The M5Stack folks changed the batter level retrieval in their M5.Power codebased. I refactored this login in M5ez as well. The battery level display remains theme based, but the code readibility is much better. I hope you like it! 