### PR TITLE
Fix loss of other preferences when WiFi preferences are saved (Issue #73)

### DIFF
--- a/src/M5ez.cpp
+++ b/src/M5ez.cpp
@@ -1209,9 +1209,9 @@ void ezSettings::defaults() {
 		Preferences prefs;
 		String idx;
 		uint8_t n = 1;
-
 		prefs.begin("M5ez", false);
-		prefs.remove("autoconnect_on");
+		// Remove unknown number of items from NVS, sequentially named SSID1 to SSIDN, and key1 to keyN where N
+		// is the total number of WiFi Networks stored (which may be different than networks.size() at this point.)
 		while (true) {
 			idx = "SSID" + (String)n;
 			if(!prefs.remove(idx.c_str())) break;

--- a/src/M5ez.cpp
+++ b/src/M5ez.cpp
@@ -1207,14 +1207,23 @@ void ezSettings::defaults() {
 
 	void ezWifi::writeFlash() {
 		Preferences prefs;
+		String idx;
+		uint8_t n = 1;
+
 		prefs.begin("M5ez", false);
-		prefs.clear();
+		prefs.remove("autoconnect_on");
+		while (true) {
+			idx = "SSID" + (String)n;
+			if(!prefs.remove(idx.c_str())) break;
+			idx = "key" + (String)n;
+			prefs.remove(idx.c_str());
+			n++;
+		}
 		prefs.putBool("autoconnect_on", autoConnect);
 		#ifdef M5EZ_WIFI_DEBUG
 			Serial.println("wifiWriteFlash: Autoconnect is " + (String)(autoConnect ? "ON" : "OFF"));
 		#endif
-		String idx;
-		for (uint8_t n = 0; n < networks.size(); n++) {
+		for (n = 0; n < networks.size(); n++) {
 			idx = "SSID" + (String)(n + 1);
 			prefs.putString(idx.c_str(), networks[n].SSID);
 			if (networks[n].key != "") {


### PR DESCRIPTION
`ezWifi::writeFlash()` currently calls `prefs.clear()`, just as `ezSettings::defaults()` does.
Unfortunately, this removes all other settings in addition to WiFi.
This change enumerates and removes the M5ez:SSIDN and M5ez:keyN entries only before rewriting all WiFi pairs. This approach:

1. Clears only WiFi settings as intended
2. Ensures gaps are not persisted in key numbering
3. Fixes the issue w/o losing any existing settings

The result of installing the fix should be: user sees no change in settings content, and settings are no longer occasionally lost.

Alternately, WiFi settings could be moved to a different namespace ("M5ez-WiFi" instead of "M5ez") and no other code changes would be required; `prefs.clear()` in the `ezWifi::writeFlash()` context would remove only the WiFi settings. The downside of this approach is that all existing WiFi settings would be lost in the upgrade. Until `ezSettings::defaults()` was called (if ever) the old WiFi prefs would remain, inaccessible,  in NVS in the old namespace. `ezSettings::defaults()` would need a trivial change as well. This approach could have the unfortunate side-effect of giving the first impression that a reliability fix is _less_ reliable by losing existing WiFi preferences, which are somewhat tedious to enter.

Changing the format of how WiFi prefs are stored in the same namespace would share the same drawbacks as changing the namespace, plus the risks inherent in the introduction of new code. As WiFi settings are currently rock solid, this seems unnecessarily risky.