### PR TITLE
fix for wifi fail: "Reason: 203 - ASSOC_FAIL"

### DIFF
--- a/src/M5ez.h
+++ b/src/M5ez.h
@@ -549,7 +549,6 @@ class ezSettings {
 			static String updateError();
 		private:
 			static WifiState_t _state;
-			static uint8_t _current_from_scan;
 			static uint32_t _wait_until, _widget_time;
 			static void _drawWidget(uint16_t x, uint16_t w);
 			static bool _onOff(ezMenu* callingMenu);


### PR DESCRIPTION
In response to issue #50, I found that the first autoconnect connection attempt often results in:

> [D][WiFiGeneric.cpp:337] _eventCallback(): Event: 5 - STA_DISCONNECTED
[W][WiFiGeneric.cpp:353] _eventCallback(): Reason: 203 - ASSOC_FAIL

...almost immediately, which results in an eventual timeout while testing for `WiFi.isConnected()`.
This change tests the state for **WL_CONNECT_FAILED** (set by the condition above) and immediately retries in this case, which seems to always succeed in my testing.
Note that there appears to be a WiFi bug in which `WiFi.disconnect()` does not set the `WiFi.state(`) to **WL_DISCONNECTED**, so once the **WL_CONNECT_FAILED** state is encountered, it persists until another asynchronous event completes. This requires our calling `WiFi._setStatus(WL_DISCONNECTED)` before `WiFi.begin(...)` in order to be able to test the state accurately.

I found that with these changes, I did not have to change timing constants at all to substantially increase autoconnect speed.
Substantial additions were made to **M5EZ_WIFI_DEBUG** statements, but these are normally omitted from the build by definition, and with the additions a connection is much easier to track in the serial monitor.

The real world of WiFi in incredibly diverse. It's difficult to be highly confident about this change without broader testing. Any feedback will be appreciated.