### PR TITLE
Correct: Improved backlight handling and charging

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,11 +1,11 @@
 name=M5ez
-version=2.3.0
+version=2.3.1
 author=Rop Gonggrijp
-maintainer=Rop Gonggrijp
+maintainer=Rop Gonggrijp, Roberto Coli
 sentence=Complete interface builder for the M5Stack, an ESP32 based mini tinker-computer
-paragraph=See more on https://github.com/M5ez/M5ez
+paragraph=See more on https://github.com/antimix/M5ez
 category=Display
-url=https://github.com/M5ez/M5ez
+url=https://github.com/antimix/M5ez
 architectures=esp32
 includes=M5ez.h
 depends=ezTime, M5Stack

--- a/src/M5ez.cpp
+++ b/src/M5ez.cpp
@@ -863,8 +863,9 @@ void ezSettings::defaults() {
 				_ButA_LastChg = M5.BtnA.lastChange();
 				_ButB_LastChg = M5.BtnB.lastChange();
 				_ButC_LastChg = M5.BtnC.lastChange();
-
+			}
 		}
+
 		if (_backlight_off || _inactive) {
 			ez.yield();
 			if (_ButA_LastChg != M5.BtnA.lastChange() || _ButB_LastChg != M5.BtnB.lastChange() || _ButC_LastChg != M5.BtnC.lastChange()) {

--- a/src/M5ez.h
+++ b/src/M5ez.h
@@ -458,6 +458,10 @@ class ezSettings {
 			static uint8_t _inactivity;
 			static uint32_t _last_activity;
 			static bool _backlight_off;
+			static bool _inactive;
+			static uint32_t _ButA_LastChg;
+			static uint32_t _ButB_LastChg;
+			static uint32_t _ButC_LastChg;
 		//
 	};
 #endif
@@ -632,7 +636,9 @@ class ezSettings {
 			static uint16_t loop();
 			static uint8_t getTransformedBatteryLevel();
 			static uint32_t getBatteryBarColor(uint8_t batteryLevel);
+			static void adaptChargeMode();
 		private:
+			static bool _canControl;
 			static bool _on;
 			static void _refresh();
 			static void _drawWidget(uint16_t x, uint16_t w);


### PR DESCRIPTION
Now when back-lite mode is on (LCD is off) , other tasks can run.
The back light button waiting cycle event does not loop anymore preventing other scheduled tasks to run.
Add better support for charging mode.